### PR TITLE
Add CMake build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ linux/starterkit32
 linux/starterkit64
 linux/res
 storage.data
+
+# CMake build
+build/
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,100 @@
+cmake_minimum_required(VERSION 3.15)
+project(starterkit C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Common flags
+set(COMMON_CFLAGS -Wall -Wextra -Wshadow -Wno-unused-parameter -Wno-switch -pedantic-errors -fcommon)
+
+# OS specific settings
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_compile_definitions(LINUX)
+    set(OS_LIBS m pthread dl rt X11 GL)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    add_compile_definitions(WINDOWS)
+    set(OS_LIBS opengl32 gdi32 ole32 comdlg32)
+elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    add_compile_definitions(OSX)
+    add_compile_options(-mmacosx-version-min=10.9 -arch x86_64 -arch arm64)
+    list(APPEND OS_LIBS
+        "-framework CoreVideo" "-framework IOKit" "-framework Cocoa"
+        "-framework GLUT" "-framework OpenGL")
+endif()
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+file(GLOB PROJECT_SOURCES
+    src/*.c
+    src/systems/*.c
+    src/managers/*.c
+    src/scenes/*.c
+)
+add_executable(${PROJECT_NAME} ${PROJECT_SOURCES})
+
+target_include_directories(${PROJECT_NAME} PRIVATE src src/managers src/scenes)
+
+target_compile_options(${PROJECT_NAME} PRIVATE ${COMMON_CFLAGS})
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE DEBUG)
+else()
+    target_compile_options(${PROJECT_NAME} PRIVATE -Ofast -ffast-math)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE RELEASE NDEBUG)
+endif()
+
+# Vendor libraries
+file(GLOB RAYLIB_SOURCES vendor/raylib/*.c)
+add_library(raylib STATIC ${RAYLIB_SOURCES})
+target_compile_options(raylib PRIVATE -w -fcommon)
+target_compile_definitions(raylib PUBLIC PLATFORM_DESKTOP)
+target_include_directories(raylib PUBLIC vendor/raylib vendor/raylib/external/glfw/include)
+
+file(GLOB FLECS_SOURCES vendor/flecs/*.c)
+add_library(flecs STATIC ${FLECS_SOURCES})
+target_include_directories(flecs PUBLIC vendor/flecs)
+
+file(GLOB CJSON_SOURCES vendor/cJSON/*.c)
+add_library(cjson STATIC ${CJSON_SOURCES})
+target_include_directories(cjson PUBLIC vendor/cJSON)
+
+file(GLOB CHIPMUNK_SOURCES vendor/Chipmunk2D/*.c)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    list(FILTER CHIPMUNK_SOURCES EXCLUDE REGEX "cpHastySpace.c")
+endif()
+add_library(chipmunk STATIC ${CHIPMUNK_SOURCES})
+target_include_directories(chipmunk PUBLIC vendor/Chipmunk2D vendor/Chipmunk2D/chipmunk)
+
+file(GLOB TINYFILEDIALOGS_SOURCES vendor/tinyfiledialogs/*.c)
+add_library(tinyfiledialogs STATIC ${TINYFILEDIALOGS_SOURCES})
+target_include_directories(tinyfiledialogs PUBLIC vendor/tinyfiledialogs)
+
+file(GLOB NUKLEAR_SOURCES vendor/Nuklear/*.c)
+add_library(nuklear STATIC ${NUKLEAR_SOURCES})
+target_compile_definitions(nuklear PRIVATE STBRP_STATIC)
+target_include_directories(nuklear PUBLIC vendor/Nuklear)
+
+foreach(lib flecs cjson chipmunk tinyfiledialogs nuklear)
+    target_compile_options(${lib} PRIVATE ${COMMON_CFLAGS})
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        target_compile_definitions(${lib} PRIVATE DEBUG)
+    else()
+        target_compile_options(${lib} PRIVATE -Ofast -ffast-math)
+        target_compile_definitions(${lib} PRIVATE RELEASE NDEBUG)
+    endif()
+endforeach()
+
+# Link everything
+target_link_libraries(${PROJECT_NAME}
+    raylib
+    flecs
+    cjson
+    chipmunk
+    tinyfiledialogs
+    nuklear
+    ${OS_LIBS}
+)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ You can run the project in VSCode. From the command-line, it's just:
 > make
 ```
 
+Alternatively, using CMake:
+
+```
+> cmake -S . -B build
+> cmake --build build
+```
+
 ## Releasing
 
 You can release your project to itch.io as follows:


### PR DESCRIPTION
## Summary
- introduce CMakeLists.txt mirroring Makefile build flags and vendor dependencies
- document building via CMake and ignore generated build artifacts

## Testing
- `cmake -S . -B build`
- `cmake --build build -j8`

------
https://chatgpt.com/codex/tasks/task_e_689a9e1177e48329ba9abc006eab9c75